### PR TITLE
develop -> v1

### DIFF
--- a/.github/workflows/publish-docs-v1-to-production.yml
+++ b/.github/workflows/publish-docs-v1-to-production.yml
@@ -50,4 +50,4 @@ jobs:
           files: |
             docs/index.html text/html nb
             docs/files/veileder-apne-data.pdf application/pdf nb files/veileder-apne-data.pdf
-            docs/images/digitaliseringsdirektoratet.png image/png nb images/digitaliseringsdirektoratet.png
+            docs/images/Digdir.png image/png nb images/Digdir.png

--- a/.github/workflows/publish-docs-v1-to-staging.yml
+++ b/.github/workflows/publish-docs-v1-to-staging.yml
@@ -50,4 +50,4 @@ jobs:
           files: |
             docs/index.html text/html nb
             docs/files/veileder-apne-data.pdf application/pdf nb files/veileder-apne-data.pdf
-            docs/images/digitaliseringsdirektoratet.png image/png nb images/digitaliseringsdirektoratet.png
+            docs/images/Digdir.png image/png nb images/Digdir.png


### PR DESCRIPTION
Trinn 2/2 (for å få de siste endringene i develop-branchen over til v1-branchen og derfra til data.norge.no - å rette på feil i workflow slik at Digdir-logoen blir med ut til data.norge.no).