### PR TITLE
chore: migrate v1 workflows to reusable workflows (#32)

### DIFF
--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -2,7 +2,6 @@ name: build adocs and publish develop to GitHub pages
 
 permissions:
   contents: write
-  pages: write
 
 on:
   push:
@@ -13,36 +12,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: avattathil/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: avattathil/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/veileder-apne-data.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+  build-adocs:
+    name: Build adocs and deploy to GitHub Pages
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/veileder-apne-data.pdf -a lang=nb docs/main.adoc
+      publish_branch: gh-pages
+      publish_dir: ./docs
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/adocs-build-v1.yml
+++ b/.github/workflows/adocs-build-v1.yml
@@ -2,7 +2,6 @@ name: build adocs and publish v1 to production (legacy)
 
 permissions:
   contents: write
-  pages: write
 
 on:
   push:
@@ -13,38 +12,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-          ref: v1
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: avattathil/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: avattathil/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/veileder-apne-data.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: html
-          publish_dir: ./docs
+  build-adocs:
+    name: Build adocs and deploy to GitHub Pages
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/veileder-apne-data.pdf -a lang=nb docs/main.adoc
+      publish_branch: html
+      publish_dir: ./docs
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-docs-v1-to-production.yml
+++ b/.github/workflows/publish-docs-v1-to-production.yml
@@ -12,45 +12,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-          ref: v1
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main    
-
-      - name: Build html
-        id: adocbuild
-        uses: avattathil/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: avattathil/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/veileder-apne-data.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.1.0
-        id: upload-rdf
-        with:
-          ontology-type: "guide"
-          ontology: "veileder-apne-data"
-          host: "https://fellesdatakatalog.digdir.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/veileder-apne-data.pdf application/pdf nb files/veileder-apne-data.pdf
-            docs/images/Digdir.png image/png nb images/Digdir.png
+  upload-files-to-production:
+    name: Upload guide to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/veileder-apne-data.pdf -a lang=nb docs/main.adoc
+      host: https://fellesdatakatalog.digdir.no
+      ontology: veileder-apne-data
+      ontology-type: guide
+      files: |
+        docs/index.html text/html nb
+        docs/files/veileder-apne-data.pdf application/pdf nb files/veileder-apne-data.pdf
+        docs/images/Digdir.png image/png nb images/Digdir.png
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/publish-docs-v1-to-staging.yml
+++ b/.github/workflows/publish-docs-v1-to-staging.yml
@@ -12,45 +12,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-          ref: v1
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: avattathil/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: avattathil/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/veileder-apne-data.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.1.0
-        id: upload-rdf
-        with:
-          ontology-type: "guide"
-          ontology: "veileder-apne-data"
-          host: "https://staging.fellesdatakatalog.digdir.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY_STAGING }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/veileder-apne-data.pdf application/pdf nb files/veileder-apne-data.pdf
-            docs/images/Digdir.png image/png nb images/Digdir.png
+  upload-files-to-staging:
+    name: Upload guide to static-rdf-server (staging)
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/veileder-apne-data.pdf -a lang=nb docs/main.adoc
+      host: https://staging.fellesdatakatalog.digdir.no
+      ontology: veileder-apne-data
+      ontology-type: guide
+      files: |
+        docs/index.html text/html nb
+        docs/files/veileder-apne-data.pdf application/pdf nb files/veileder-apne-data.pdf
+        docs/images/Digdir.png image/png nb images/Digdir.png
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY_STAGING }}


### PR DESCRIPTION
Migrates the **v1 branch** workflows to call the central `Informasjonsforvaltning/workflows` reusable workflows, mirroring the migration done on `develop`. Resolves #32 for the v1 branch.

## What changed
| Workflow | Now calls |
|---|---|
| `adocs-build-develop.yml` | `specification-github-pages.yaml@main` |
| `adocs-build-v1.yml` (legacy → `html` branch) | `specification-github-pages.yaml@main` |
| `publish-docs-v1-to-production.yml` | `specification-upload-files.yaml@main` |
| `publish-docs-v1-to-staging.yml` | `specification-upload-files.yaml@main` |

All `on:` triggers are preserved verbatim. The bespoke checkout / submodule-update / asciidoctor-build / deploy / upload steps are now handled inside the reusable workflows.

## Why (issue #32)
Removes all unpinned third-party action references from the v1 branch — `actions/checkout@v4`, `avattathil/asciidoctor-action@master`, `peaceiris/actions-gh-pages@v3`, `upload-files-to-static-rdf-server-action@v3.1.0`. The reusable workflows pin everything to commit SHAs internally (checkout v6, asciidoctor by image digest, gh-pages v4, upload-action v3.3.0).

## Notes / things to verify
- **`publish_branch: gh-pages`** on `adocs-build-develop.yml`: the old workflow set no branch, so peaceiris defaulted to `gh-pages`. Made explicit (reusable workflow requires it). Confirm the Pages source branch.
- **PDF build is no longer `continue-on-error`**: a failed `asciidoctor-pdf` now fails the job (previously HTML still deployed). Stricter, but a behavior change.
- `adocs-build-develop.yml` is dormant on `v1` (its `push: develop` filter never matches v1) but kept + migrated to preserve byte-identical parity with `develop`, so future `develop → v1` merges stay conflict-free.